### PR TITLE
Add devcontainer support (and instructions) to starter guide

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+# syntax = docker/dockerfile:1.0-experimental
+FROM registry.access.redhat.com/ubi8/nodejs-12 as podmandevcontainer
+
+USER root
+
+RUN dnf update -y && npm i -g @antora/cli@2.3 @antora/site-generator-default@2.3 \
+    && dnf update -y \
+    && npm rm --global npx && npm install --global npx && npm install --global gulp \
+    && dnf clean all && rm -r /var/cache/dnf
+
+RUN wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64 -O /usr/local/bin/yq && \
+    chmod 755 /usr/local/bin/yq
+
+RUN wget https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64 -O /usr/local/bin/stern && \
+    chmod 755 /usr/local/bin/stern
+
+RUN curl -L https://github.com/tektoncd/cli/releases/download/v0.12.1/tkn_0.12.1_Linux_x86_64.tar.gz | \
+    tar -xvzf - -C /usr/local/bin/ tkn && chmod 755 /usr/local/bin/tkn && \
+    wget -qO- https://mirror.openshift.com/pub/openshift-v4/clients/serverless/0.16.1/kn-linux-amd64-0.16.1.tar.gz | tar -zxvf - -C /usr/local/bin ./kn && chmod 755 /usr/local/bin/kn 
+
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | \
+    tar -xvzf - -C /usr/local/bin/ oc && chmod 755 /usr/local/bin/oc && ln -s /usr/local/bin/oc /usr/local/bin/kubectl
+
+# If running (rootless) podman, keep the root user so that outside the container it will match 
+# the host user.  Otherwise run as default user
+FROM podmandevcontainer AS devcontainer
+RUN chown -R default $HOME
+USER default

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 	
 	"runArgs": [
 		"-v", "${env:HOME}/.kube:/opt/app-root/src/.kube:Z",
-		"-v", "${env:HOME}/.gitconfig:/opt/app-root/src/.gitconfig",
+		"-v", "${env:HOME}/.gitconfig:/opt/app-root/src/.gitconfig:Z",
+		"-e", "WORKSPACE_ROOT=${containerWorkspaceFolder}"
 	],
 
 	// Set *default* container specific settings.json values on container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"name": "OpenShift Starter Guide",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"target": "${env:DEVCONTAINER_TARGET_PREFIX}DEVCONTAINER",
+		"target": "${env:DEVCONTAINER_TARGET_PREFIX}devcontainer",
 	},
 	
 	"runArgs": [
@@ -28,5 +28,5 @@
 	"forwardPorts": [3000],
 
 	// Specifies a command that should be run after the container has been created.
-	"postCreateCommand": "yarn install && rsync -a .devcontainer/workspace-setup/ ${containerWorkspaceFolder}/.vscode/ --ignore-existing",
+	"postCreateCommand": "rsync -a .devcontainer/workspace-setup/ ${containerWorkspaceFolder}/.vscode/ --ignore-existing",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
+		"editor.tabCompletion": "on",
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/javascript-node
+{
+	"name": "OpenShift Starter Guide",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"target": "${env:DEVCONTAINER_TARGET_PREFIX}DEVCONTAINER",
+	},
+	
+	"runArgs": [
+		"-v", "${env:HOME}/.kube:/opt/app-root/src/.kube:Z",
+		"-v", "${env:HOME}/.gitconfig:/opt/app-root/src/.gitconfig",
+	],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"ms-azuretools.vscode-docker",
+		"joaompinto.asciidoctor-vscode",
+	],
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000],
+
+	// Specifies a command that should be run after the container has been created.
+	"postCreateCommand": "yarn install && rsync -a .devcontainer/workspace-setup/ ${containerWorkspaceFolder}/.vscode/ --ignore-existing",
+}

--- a/.devcontainer/workspace-setup/asciidoc.json.code-snippets
+++ b/.devcontainer/workspace-setup/asciidoc.json.code-snippets
@@ -1,0 +1,48 @@
+{
+  "Add Tabs": {
+    "prefix": "tabs",
+    "body": [
+      "[tabs]",
+      "====",
+      "${1:tab1}::",
+      "+",
+      "--",
+      "--",
+      "${2:tab2}::",
+      "+",
+      "--",
+      "--",
+      "===="
+    ],
+    "description": "Add Tabs macro"
+  },
+  "Add Navigation": {
+    "prefix": "nav",
+    "body": [
+      "${1|*,**,***|} xref:${2:page.adoc}[${3:Nav Title}]"
+    ],
+    "description": "Add new navigation"
+  },
+  "Console Input": {
+    "prefix": "input",
+    "body": [
+      "[.console-input]",
+      "[source,${1:bash},subs=\"${2:+macros,+attributes}\"]",
+      "----",
+      "${3:echo \"Hello World\"}",
+      "----"
+    ],
+    "description": "Adds Console Input source fragment"
+  },
+  "Console Output": {
+    "prefix": "output",
+    "body": [
+      "[.console-output]",
+      "[source,${1:bash},subs=\"${2:+macros,+attributes}\"]",
+      "----",
+      "${3:\"Hello World\"}",
+      "----"
+    ],
+    "description": "Adds Console Output source fragment"
+  }
+}

--- a/.devcontainer/workspace-setup/tasks.json
+++ b/.devcontainer/workspace-setup/tasks.json
@@ -6,7 +6,6 @@
 			"type": "npm",
 			"script": "dev",
 			"problemMatcher": [],
-			"detail": "gulp",
 			"dependsOn":[ "npm install" ]
 		},
 		{

--- a/.devcontainer/workspace-setup/tasks.json
+++ b/.devcontainer/workspace-setup/tasks.json
@@ -1,0 +1,18 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Build and watch dev-site",
+			"type": "npm",
+			"script": "dev",
+			"problemMatcher": [],
+			"detail": "gulp",
+			"dependsOn":[ "npm install" ]
+		},
+		{
+			"label": "npm install",
+			"type": "npm",
+			"script": "install"
+		}
+	]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ package*
 node_modules
 .firebaserc
 .firebase
+
+### Antora ###
+
+# for local testing/publishing of content
+stage-*-site.yml

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -3,6 +3,19 @@
 The sources of this tutorial docs is in https://github.com/redhat-scholars/openshift-starter-guides/tree/master/documentation[documentation] folder.
 The site generation is done by https://docs.antora.org/[Antora]
 
+### Visual Studio Code Remote Development
+
+If you are using [Visual Studio Code](https://code.visualstudio.com/) with the [Remote Containers Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), you don't need to install anything locally.
+
+Simply follow these instructions:
+
+1. (Only if running with podman) Set the environment variable `DEVCONTAINER_TARGET_PREFIX=podman`
+2. Open VS Code from the root of `openshift-starter-guides` repository and when prompted indicate that you want to open the folder in a container.
+
+Once the devcontainer is initialized, from the Visual Studio Code terminal run `npm run dev` to start the development site.  (Visual Studio Code should handle all the port forwarding into the devcontainer so that you can interact with the site from an VSCode assigned port on your localhost)
+
+Alternatively, you can run the `Build and watch dev-site` VSCode task that should be installed in your workspace when starting up the container
+
 ## Running site in development mode
 
 To run the site in development mode you need to have https://yarnpkg.com[yarn] or https://nodejs.org/en/[npm] installed with https://nodejs.org[NodeJS] v12.x or above.

--- a/github-pages-publish.sh
+++ b/github-pages-publish.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+declare SITE=${1:-site.yml}
+declare REPO=${2:-$(git remote get-url origin)}
+declare BRANCH="gh-pages"
+declare _CURR_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+# NOTE: WORKSPACE_ROOT defined from devcontainer.json if running from within vscode
+declare REPO_ROOT=${WORKSPACE_ROOT:-${_CURR_DIR}}
+
+echo "Removing old publish directory"
+if [[ -d $REPO_ROOT/gh-pages ]]; then
+    rm -rf $REPO_ROOT/gh-pages 
+fi
+
+echo "Removing antora cache directory"
+if [[ -d $REPO_ROOT/.cache ]]; then
+    rm -rf $REPO_ROOT/.cache 
+fi
+
+git clone -b ${BRANCH} ${REPO} $REPO_ROOT/gh-pages
+
+echo "Generating the site documentation from ${SITE}"
+
+antora generate --stacktrace $REPO_ROOT/${SITE} --to-dir $REPO_ROOT/gh-pages
+
+echo "Pushing site to ${BRANCH} branch of ${REPO}"
+cd $REPO_ROOT/gh-pages
+git add --all .
+git commit -m"Automated Publish" 
+git push origin
+
+echo "Site published successfully!"

--- a/site.sh
+++ b/site.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+declare SITE_YAML=${1:-site.yml}
+
 _CURR_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 rm -rf $_CURR_DIR/gh-pages $_CURR_DIR/.cache
 
-antora --pull --stacktrace  site.yml
+antora --pull --stacktrace ${SITE_YAML}


### PR DESCRIPTION
For those that have Visual Studio remote containers installed, this adds a Dockerfile environment (that should work with both docker and podman) for editing and updating the starter guide content (and testing said content).  

Automatically installs helpful snippets for guide (e.g. input and output) and adds tasks for starting antora watch

Updates contributing.adoc with instructions on this

Adds a script for automatically publishing site to github pages (based on a given antora site.yml)